### PR TITLE
fix: update footer link to startupjunto.org

### DIFF
--- a/src/components/app-footer/app-footer.tsx
+++ b/src/components/app-footer/app-footer.tsx
@@ -81,7 +81,7 @@ export class AppFooter {
               <h2>{translate('footer.webinar.signup')}</h2>
               <p>{translate('footer.webinar.webinarText')}</p>
               <a
-                href="http://learn.openforge.io/"
+                href="http://startupjunto.org/"
                 target="_blank"
                 rel="noopener"
                 class="footer--btn btn btn-primary"


### PR DESCRIPTION
Updated footer link to redirect to the startupjunto.org instead of the previous site that was listed.

Link to Teamwork task:
https://openforge.teamwork.com/#tasks/12014937